### PR TITLE
Fit to Window mode

### DIFF
--- a/sources/myparams.h
+++ b/sources/myparams.h
@@ -105,11 +105,12 @@ class MyParams : public QObject  // singleton
   QMap<int, QImage> m_scribbleImages;
   QMap<int, bool> m_dirtyFlags;
 
-  // tools
+  // environment
   QMap<ToolId, Tool*> m_tools;
   ToolId m_currentToolId;
   QColor m_currentColor;
   QCursor m_brushCursor;
+  bool m_fitToWindow;
 
   // undo stack
   QUndoStack* m_undoStack;
@@ -293,6 +294,9 @@ public:
 
   const QColor currentColor() { return m_currentColor; }
   void setCurrentColor(QColor col) { m_currentColor = col; }
+
+  const bool isFitToWindow() { return m_fitToWindow; }
+  void setIsFitToWindow(const bool on) { m_fitToWindow = on; }
 
   QUndoStack* undoStack() { return m_undoStack; }
 

--- a/sources/xsheetpreviewarea.h
+++ b/sources/xsheetpreviewarea.h
@@ -371,6 +371,7 @@ protected:
   void contextMenuEvent(QContextMenuEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
+  void resizeEvent(QResizeEvent* event) override;
 
 public:
   XsheetPdfPreviewArea(QWidget* parent);


### PR DESCRIPTION
This PR will make the `Fit To Window` context menu command to be checkable (i.e. a mode that can be turned on and off).
If the `Fit To Window` is ON, when the window is resized, the panel automatically zooms to show the entire page.
This mode will be automatically deactivated when zooming with the tool buttons or mouse wheel.