### PR TITLE
Fix Export Image and Scribble Image Files Numbering

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # Specify the project name
-project(xdts_viewer VERSION 1.1.0)
+project(xdts_viewer VERSION 1.2.0)
 
 set(MOC_HEADERS
     mywindow.h

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[]) {
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication a(argc, argv);
   a.setApplicationName("XDTS Viewer");
-  a.setApplicationVersion("1.1.0");
+  a.setApplicationVersion("1.2.0");
 
   // Compress tablet events with application attributes instead of implementing
   // the delay-timer by ourselves

--- a/sources/myparams.h
+++ b/sources/myparams.h
@@ -47,6 +47,8 @@ class MyParams : public QObject  // singleton
 
   QMap<QString, QString> m_templatesMap;
 
+  QString m_createdVersion;
+
   // format settings
   QString m_templateName;
   ExportArea m_exportArea;
@@ -129,6 +131,8 @@ public:
 
   // to be called just after instancing the application
   void initialize();
+
+  QString createdVersion() const { return m_createdVersion; }
 
   void setTemplateName(const QString& val) { m_templateName = val; }
   QString templateName() const { return m_templateName; }

--- a/sources/mywindow.cpp
+++ b/sources/mywindow.cpp
@@ -1098,7 +1098,7 @@ void MyWindow::onExport() {
 
       pm.save(tmpFile);
 
-      if (fpage == 0) {
+      if (fpage == -1) {
         currentPage++;
         break;
       }


### PR DESCRIPTION
This PR fixes the following bug:
- When exporting PNG images, scribble layers appear on wrong pages.

Also this PR modifies the file numbering for the scribble images when the level amount is larger than the template's column amount. Now the page numbers starts from 1, in order to be consistent with the actual page number appeared on the interface.

**[BEFORE]**  0.png(backside), 0A.png, 0B.png, 1A.png, 1B.png,...
**[AFTER]**  0.png(backside), 1A.png, 1B.png, 2A.png, 2B.png,...

I incremented the version number to `V1.2.0`, so that the settings created with the older versions will load images in the conventional manner and keep compatibility.