### PR TITLE
Fix showing frame continuing from the previous page

### DIFF
--- a/sources/myparams.cpp
+++ b/sources/myparams.cpp
@@ -21,7 +21,7 @@ const QStringList exportAreaNameList = {"Actions", "Cells"};
 // 1.2.3 -> 10203  1.10.0 -> 11000
 int VersionValue(QString versionStr) {
   QStringList vList = versionStr.split(".");
-  assert(vList.count == 3);
+  assert(vList.count() == 3);
   return vList[0].toInt() * 10000 + vList[1].toInt() * 100 + vList[2].toInt();
 }
 

--- a/sources/xsheetpreviewarea.cpp
+++ b/sources/xsheetpreviewarea.cpp
@@ -1608,6 +1608,8 @@ void XSheetPDFTemplate::drawXsheetContents(QPainter& painter, int framePage,
 
       //  1ページ目であれば-1を返す。2ぺージ目以降の場合、前のフレームにさかのぼって継続線の開始フレームを探す
       int continuousLineStartFrame = checkPrevContinuous(cells, startFrame);
+      if (continuousLineStartFrame != -1)
+        prevCell = cells[continuousLineStartFrame];
 
       r                  = 0;
       int topColumnIndex = c, prevColumnIndex = occupiedColumns[c][0];


### PR DESCRIPTION
This PR fixes the following problem:
- When the mix-up columns appears in the second page and if the column has the continuous line of the same frames from the first page,  the cell on the mix-up columns keyframe becomes blank.