### PR TITLE
Fix Window Geometry Recovering & Fix Stamp Initialization

### DIFF
--- a/sources/aetool.cpp
+++ b/sources/aetool.cpp
@@ -195,7 +195,7 @@ bool AETool::onActivate() {
 
   // テレコ表示がONで、テレコが実際にあったら警告を出してツールを元に戻す
   XSheetPDFTemplate* tmpl = MyParams::instance()->currentTemplate();
-  if (tmpl->hasTerekoColumns(Area_Cells)) {
+  if (tmpl && tmpl->hasTerekoColumns(Area_Cells)) {
     QMessageBox::warning(
         m_view, tr("Copy After Effects Keyframe Data To Clipboard"),
         tr("There are mix-up columns in the Cell area.\nPlease turn off the "

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -8,6 +8,7 @@
 #include <QApplication>
 #include <QTranslator>
 #include <QDir>
+#include <QScreen>
 
 #ifndef __MACOS__
 #include <QtPlatformHeaders/QWindowsWindowFunctions>
@@ -49,7 +50,14 @@ int main(int argc, char* argv[]) {
   MyWindow w;
 
   QRect geometry = MyParams::instance()->loadWindowGeometry();
-  if (!geometry.isNull()) w.setGeometry(geometry);
+  if (!geometry.isNull()) {
+    for (auto screen : a.screens()) {
+      if (screen->availableGeometry().contains(geometry.center())) {
+        w.setGeometry(geometry);
+        break;
+      }
+    }
+  }
 
   w.show();
   w.initialize();

--- a/sources/myparams.cpp
+++ b/sources/myparams.cpp
@@ -129,11 +129,11 @@ void MyParams::initialize() {
     }
   }
 
+  loadUserSettingsIfExists();
+
   // マイスタンプの登録ここでやる
   registerDefaultStamps();
   loadUserStamps();
-
-  loadUserSettingsIfExists();
 
   QPixmap pm(5, 5);
   pm.fill(Qt::transparent);


### PR DESCRIPTION
This PR fixes the following problems:
- When the stored window geometry is out of the current screen, the window does not appear on the next launch.
- The "accept" name stamp fails to be initialized.
