### PR TITLE
Introduce Single Instance per File Mechanism

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MOC_HEADERS
     aetool.h
     dyetool.h
     mixupkeydialog.h
+    instancemanager.h
     )
 
 set(HEADERS
@@ -38,6 +39,7 @@ set(SOURCES
     aetool.cpp
     dyetool.cpp
     mixupkeydialog.cpp
+    instancemanager.cpp
 )
 
 #-----------------------------------------------------------------------------
@@ -85,10 +87,14 @@ if(BUILD_ENV_APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 endif()
 
-# Add Qt libraries. QtCore and QtGui libraries will be 
-# added accordingly as the Widgets depends on them. 
+# Add Qt libraries. QtCore and QtGui libraries will be
+# added accordingly as the Widgets depends on them.
+# Network is required for QLocalServer/QLocalSocket, used by InstanceManager
+# for single-instance IPC (Network は QLocalServer/QLocalSocket に必要。
+# InstanceManagerの単一起動IPCで使用する)。
 find_package( Qt5 REQUIRED
     Widgets
+    Network
     LinguistTools
 )
 
@@ -157,9 +163,9 @@ endif()
 
 # link Qt library. Core and Gui will be linked accordingly
 if(BUILD_ENV_MSVC)
-    target_link_libraries(${PROJECT_NAME} Qt5::Widgets ${PSD_SDK_LIB} )
+    target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Network ${PSD_SDK_LIB} )
 else()
-    target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+    target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Network)
 endif()
 
 add_definitions(

--- a/sources/instancemanager.cpp
+++ b/sources/instancemanager.cpp
@@ -1,0 +1,292 @@
+#include "instancemanager.h"
+#include "pathutils.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QSharedMemory>
+#include <QProcess>
+#include <QMap>
+
+#include <cstring>
+
+namespace {
+// Fixed identifiers shared by every process of this app so they can find
+// each other. Kept in one place rather than as class statics to avoid
+// static-initialization-order concerns.
+// 各プロセスが互いを見つけられるようにするための固定識別子。
+const QString kSharedMemoryKey =
+    QStringLiteral("XDTSViewer.SingleInstance.Lock");
+const QString kServerName = QStringLiteral("XDTSViewer.SingleInstance.IPC");
+}  // namespace
+
+// Internal argv flag marking a process as a worker window spawned by the
+// mothership (as opposed to a plain user-facing launch). Not translated /
+// not shown to the user.
+const QString kWorkerFlag = QStringLiteral("--xdts-worker");
+
+InstanceManager* InstanceManager::instance() {
+  static InstanceManager _instance;
+  return &_instance;
+}
+
+InstanceManager::InstanceManager(QObject* parent) : QObject(parent) {}
+
+InstanceManager::Role InstanceManager::bootstrap(const QStringList& args,
+                                                 QString& outPath) {
+  // 1. This process was spawned by the mothership as a per-file window.
+  int workerFlagIdx = args.indexOf(kWorkerFlag);
+  if (workerFlagIdx >= 0) {
+    outPath = (workerFlagIdx + 1 < args.size()) ? args.at(workerFlagIdx + 1)
+                                                : QString();
+    m_role  = Role::Worker;
+    connectAsWorker();
+    return m_role;
+  }
+
+  // Find the first non-flag argument (skip args[0], the executable path).
+  QString requestedPath;
+  for (int i = 1; i < args.size(); ++i) {
+    if (!args.at(i).startsWith(QStringLiteral("--"))) {
+      requestedPath = args.at(i);
+      break;
+    }
+  }
+
+  // 2. Try to become the mothership (the single coordinator process).
+  if (tryAcquireLock()) {
+    startMothership(requestedPath);
+    return m_role;
+  }
+
+  // 3. Another mothership is already running: forward the request to it and
+  // let the caller exit immediately without ever showing a window.
+  {
+    QLocalSocket socket;
+    socket.connectToServer(kServerName);
+    if (socket.waitForConnected(1000)) {
+      sendFrame(&socket, Command::Open, requestedPath);
+      socket.disconnectFromServer();
+      m_role = Role::Forwarded;
+      return m_role;
+    }
+  }
+
+  // 4. Rare case: QSharedMemory reported an existing mothership, but it is
+  // gone by the time we tried to connect (e.g. it just exited). Retry
+  // becoming the mothership once; otherwise fall back to legacy
+  // single-window behavior so the app still opens.
+  // 稀なケース: QSharedMemoryは既存の母艦の存在を示したが、接続を試みた
+  // 時点で既に終了している場合（例:直前に終了した等）。もう一度母艦への
+  // 昇格を試み、それも失敗すれば調整なしの単独ウィンドウ動作にフォール
+  // バックし、アプリが起動できなくなることを避ける。
+  if (tryAcquireLock()) {
+    startMothership(requestedPath);
+    return m_role;
+  }
+
+  outPath = requestedPath;
+  m_role  = Role::Standalone;
+  return m_role;
+}
+
+bool InstanceManager::tryAcquireLock() {
+  if (!m_lock) m_lock = new QSharedMemory(kSharedMemoryKey, this);
+
+  if (m_lock->create(1)) return true;
+
+  if (m_lock->error() == QSharedMemory::AlreadyExists) {
+    // On Linux/macOS a crashed process can leave a stale segment attached;
+    // attach+detach once to release it, then retry. On Windows the OS
+    // already releases the segment as soon as the owning process dies, so
+    // this branch normally means another mothership is genuinely alive.
+    // Linux/macOSではクラッシュしたプロセスが残留セグメントを残すことが
+    // あるため、一度attach+detachして解放を試みてから再試行する。Windows
+    // ではプロセス終了時にOSが自動解放するため、通常この分岐に入るのは
+    // 別の母艦が本当に稼働中の場合のみとなる。
+    if (m_lock->attach()) m_lock->detach();
+    if (m_lock->create(1)) return true;
+  }
+  return false;
+}
+
+void InstanceManager::startMothership(const QString& initialPath) {
+  m_server = new QLocalServer(this);
+  // Clear a stale socket file possibly left behind by a crashed mothership.
+  QLocalServer::removeServer(kServerName);
+  if (!m_server->listen(kServerName)) {
+    // Could not start the IPC server; fall back to legacy behavior rather
+    // than failing to launch at all.
+    m_role = Role::Standalone;
+    return;
+  }
+  connect(m_server, &QLocalServer::newConnection, this,
+          &InstanceManager::onNewConnection);
+  m_role = Role::Mothership;
+  // Treat our own launch argument the same way as a request coming from
+  // another process (always spawns a worker, since nothing is registered
+  // yet at this point).
+  handleOpenRequest(initialPath);
+}
+
+void InstanceManager::onNewConnection() {
+  while (m_server->hasPendingConnections()) {
+    QLocalSocket* socket = m_server->nextPendingConnection();
+    m_recvBuffers.insert(socket, QByteArray());
+    connect(socket, &QLocalSocket::readyRead, this,
+            &InstanceManager::onServerSocketReadyRead);
+    connect(socket, &QLocalSocket::disconnected, this,
+            &InstanceManager::onServerSocketDisconnected);
+  }
+}
+
+void InstanceManager::onServerSocketReadyRead() {
+  QLocalSocket* socket = qobject_cast<QLocalSocket*>(sender());
+  if (!socket || !m_recvBuffers.contains(socket)) return;
+
+  QByteArray& buffer = m_recvBuffers[socket];
+  buffer.append(socket->readAll());
+
+  Command cmd;
+  QString path;
+  while (tryReadFrame(buffer, cmd, path)) {
+    if (cmd == Command::ClearRegistration) {
+      // A worker's open-file set is about to be re-sent from scratch
+      // (initial registration, or File > Open switched to a different
+      // file / pair). Drop this socket's previous entries first so stale
+      // paths don't keep pointing at it.
+      QMutableMapIterator<QString, QLocalSocket*> it(m_workers);
+      while (it.hasNext()) {
+        it.next();
+        if (it.value() == socket) it.remove();
+      }
+    } else if (cmd == Command::Register) {
+      // Registers one path this worker currently has open. A paired
+      // genga/douga sheet sends both paths, so either one resolves to this
+      // window.
+      m_workers.insert(PathUtils::canonicalizePath(path), socket);
+    } else if (cmd == Command::Open) {
+      // A short-lived forwarder is relaying an open request; it will
+      // disconnect on its own right after this.
+      handleOpenRequest(path);
+    }
+  }
+}
+
+void InstanceManager::onServerSocketDisconnected() {
+  QLocalSocket* socket = qobject_cast<QLocalSocket*>(sender());
+  if (!socket) return;
+
+  m_recvBuffers.remove(socket);
+
+  // A registered worker window closed (or crashed): drop it from the
+  // registry so a later "open" request for the same path spawns a new one.
+  QMutableMapIterator<QString, QLocalSocket*> it(m_workers);
+  while (it.hasNext()) {
+    it.next();
+    if (it.value() == socket) it.remove();
+  }
+  socket->deleteLater();
+
+  // All windows are closed: the mothership has no reason to keep running.
+  if (m_workers.isEmpty()) qApp->quit();
+}
+
+void InstanceManager::handleOpenRequest(const QString& path) {
+  QString canonical = PathUtils::canonicalizePath(path);
+  if (!canonical.isEmpty() && m_workers.contains(canonical)) {
+    // Already open in a worker window: ask it to reload and come forward
+    // instead of starting a new process.
+    sendFrame(m_workers.value(canonical), Command::Reload, QString());
+    return;
+  }
+  spawnWorker(path);
+}
+
+void InstanceManager::spawnWorker(const QString& path) {
+  QStringList args;
+  args << kWorkerFlag;
+  if (!path.isEmpty()) args << path;
+  QProcess::startDetached(QCoreApplication::applicationFilePath(), args);
+}
+
+void InstanceManager::connectAsWorker() {
+  m_workerSocket = new QLocalSocket(this);
+  connect(m_workerSocket, &QLocalSocket::readyRead, this,
+          &InstanceManager::onWorkerSocketReadyRead);
+  m_workerSocket->connectToServer(kServerName);
+  m_workerSocket->waitForConnected(1000);
+  // If this fails (the mothership died between spawning us and connecting),
+  // later sendFrame() calls (registration, notifyPathChanged) silently no-op;
+  // the window still opens and behaves normally, it just won't participate
+  // in reload/activate coordination.
+  // 接続に失敗した場合（起動直後に母艦が終了した等）、このウィンドウは
+  // 以後のreload/activate通知を受け取れなくなるが、ウィンドウ自体は通常
+  // 通り開いて動作する。
+}
+
+void InstanceManager::notifyPathChanged(const QStringList& paths) {
+  if (m_role != Role::Worker || !m_workerSocket) return;
+
+  // Re-send this window's full open-path set from scratch: a paired
+  // genga/douga sheet occupies two paths, so a plain "update one path"
+  // message would leave the other one stuck pointing at whatever was
+  // registered before.
+  sendFrame(m_workerSocket, Command::ClearRegistration, QString());
+  for (const QString& path : paths) {
+    if (!path.isEmpty()) sendFrame(m_workerSocket, Command::Register, path);
+  }
+}
+
+void InstanceManager::onWorkerSocketReadyRead() {
+  m_workerRecvBuffer.append(m_workerSocket->readAll());
+
+  Command cmd;
+  QString path;
+  while (tryReadFrame(m_workerRecvBuffer, cmd, path)) {
+    if (cmd == Command::Reload) emit reloadAndActivateRequested();
+  }
+}
+
+bool InstanceManager::sendFrame(QLocalSocket* socket, Command cmd,
+                                const QString& path) {
+  if (!socket) return false;
+
+  // Length-prefixed framing: QLocalSocket is a byte stream with no message
+  // boundaries, so a 4-byte size header precedes each payload. This also
+  // keeps the protocol safe for paths containing unusual characters, unlike
+  // a delimiter-based scheme.
+  // QLocalSocketはバイトストリームでありメッセージの区切りを保証しない
+  // ため、各ペイロードの前に4バイトの長さヘッダを付与する（フレーミング）。
+  // 区切り文字方式と異なり、パスに特殊な文字が含まれていても安全。
+  QByteArray payload;
+  payload.append(static_cast<char>(cmd));
+  payload.append(path.toUtf8());
+
+  quint32 len = static_cast<quint32>(payload.size());
+  QByteArray frame;
+  frame.append(reinterpret_cast<const char*>(&len), sizeof(len));
+  frame.append(payload);
+
+  socket->write(frame);
+  return socket->waitForBytesWritten(1000);
+}
+
+bool InstanceManager::tryReadFrame(QByteArray& buffer, Command& cmd,
+                                   QString& path) {
+  if (buffer.size() < static_cast<int>(sizeof(quint32))) return false;
+
+  quint32 len;
+  std::memcpy(&len, buffer.constData(), sizeof(len));
+  if (buffer.size() < static_cast<int>(sizeof(quint32) + len)) return false;
+
+  QByteArray payload = buffer.mid(sizeof(quint32), len);
+  buffer.remove(0, sizeof(quint32) + len);
+
+  if (payload.isEmpty()) return false;  // malformed frame; drop it
+
+  cmd  = static_cast<Command>(static_cast<quint8>(payload.at(0)));
+  path = QString::fromUtf8(payload.mid(1));
+  return true;
+}

--- a/sources/instancemanager.h
+++ b/sources/instancemanager.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#ifndef INSTANCEMANAGER_H
+#define INSTANCEMANAGER_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QMap>
+#include <QByteArray>
+
+class QLocalServer;
+class QLocalSocket;
+class QSharedMemory;
+
+// Coordinates single-instance behavior for the app: a single hidden
+// "mothership" process arbitrates which XDTS file is open in which
+// per-file window ("worker") process, and forwards duplicate open
+// requests to the already-open window instead of starting a new one.
+// 単一起動の調整を行うクラス。不可視の「母艦(mothership)」プロセスが、
+// どのXDTSファイルがどのウィンドウ（"worker"）プロセスで開かれているかを
+// 管理し、重複するオープン要求は新規ウィンドウを開かず既存ウィンドウへ
+// 転送する。
+class InstanceManager : public QObject {
+  Q_OBJECT
+
+public:
+  enum class Role {
+    Standalone,  // IPC unavailable: legacy single-window behavior, no
+                 // coordination
+    Mothership,  // invisible coordinator; caller must not show a window
+    Worker,      // shows a window for outPath; spawned by the mothership
+    Forwarded,  // request forwarded to an existing mothership; caller must exit
+                // immediately
+  };
+
+  static InstanceManager* instance();
+
+  // Determines this process's role from the command-line arguments and
+  // performs the corresponding IPC setup (become the mothership / connect
+  // to it / forward a request to it). `outPath` receives the XDTS path this
+  // process should show, meaningful only for the Worker/Standalone roles.
+  // Call once, right after QApplication is constructed.
+  // コマンドライン引数からこのプロセスの役割を判定し、対応するIPCの初期化
+  // （母艦になる／母艦へ接続する／母艦へ要求を転送する）を行う。outPathには
+  // このプロセスが表示すべきXDTSパスが入る（Worker/Standaloneの場合のみ
+  // 意味を持つ）。QApplication構築直後に一度だけ呼び出すこと。
+  Role bootstrap(const QStringList& args, QString& outPath);
+
+  // Re-registers this worker's currently open path(s) with the mothership
+  // (a paired genga/douga sheet occupies two paths at once). No-op unless
+  // this process's role is Worker. Call from MyWindow::onLoad() whenever the
+  // user opens a different file in this window.
+  // このワーカーが現在開いているパス（原画欄／動画欄のペアシートの場合は
+  // 2つ）を母艦へ再登録する。役割がWorker以外の場合は何もしない。
+  // ユーザーがこのウィンドウで別のファイルを開いた際にMyWindow::onLoad()
+  // から呼び出す。
+  void notifyPathChanged(const QStringList& paths);
+
+signals:
+  // Worker role only: emitted when the mothership asks this window to
+  // reload its XDTS data and come to the foreground, because another
+  // launch requested the file already open here.
+  // Worker側でのみ発火する。別の起動がこのウィンドウで既に開いている
+  // ファイルを要求したため、母艦からXDTSデータの再読み込みと前面化を
+  // 指示された際にシグナルされる。
+  void reloadAndActivateRequested();
+
+private slots:
+  void onNewConnection();          // mothership: a new incoming connection
+  void onServerSocketReadyRead();  // mothership: data from a worker/forwarder
+  void onServerSocketDisconnected();
+  void onWorkerSocketReadyRead();  // worker: data pushed from the mothership
+
+private:
+  explicit InstanceManager(QObject* parent = nullptr);
+
+  enum class Command : quint8 {
+    Register          = 0,
+    Open              = 1,
+    Reload            = 2,
+    ClearRegistration = 3
+  };
+
+  bool tryAcquireLock();
+  void startMothership(const QString& initialPath);
+  void connectAsWorker();
+  void handleOpenRequest(const QString& path);
+  bool sendFrame(QLocalSocket* socket, Command cmd, const QString& path);
+  static bool tryReadFrame(QByteArray& buffer, Command& cmd, QString& path);
+  void spawnWorker(const QString& path);
+
+  Role m_role            = Role::Standalone;
+  QSharedMemory* m_lock  = nullptr;
+  QLocalServer* m_server = nullptr;
+  QLocalSocket* m_workerSocket =
+      nullptr;  // Worker role: connection to the mothership
+
+  // Mothership-side bookkeeping: normalized path -> connected worker socket,
+  // plus a per-socket receive buffer for length-prefixed message framing.
+  QMap<QString, QLocalSocket*> m_workers;
+  QMap<QLocalSocket*, QByteArray> m_recvBuffers;
+
+  // Worker-side receive buffer for messages pushed by the mothership.
+  QByteArray m_workerRecvBuffer;
+};
+
+#endif

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -1,6 +1,7 @@
 #include "mywindow.h"
 #include "myparams.h"
 #include "pathutils.h"
+#include "instancemanager.h"
 
 #include <iostream>
 
@@ -26,6 +27,22 @@ int main(int argc, char* argv[]) {
   a.setAttribute(Qt::AA_CompressHighFrequencyEvents);
   a.setAttribute(Qt::AA_CompressTabletEvents);
 
+  // Single-instance / multi-window coordination. Use QApplication::arguments()
+  // (not raw argv) so non-ASCII paths survive on Windows. A Forwarded process
+  // has already handed its request to the running mothership and must exit
+  // without doing any of the setup below; a Mothership process never shows a
+  // window and just serves IPC requests until every worker window has closed.
+  // 単一起動・マルチウィンドウの調整。非ASCIIパスがWindowsで壊れないよう、
+  // 生のargvではなくQApplication::arguments()を使う。Forwarded(転送済み)の
+  // 場合は既に稼働中の母艦へ要求を渡し終えているため、以下の初期化を一切
+  // 行わずに終了する。Mothership(母艦)の場合はウィンドウを表示せず、全ての
+  // ワーカーウィンドウが閉じるまでIPC要求を処理し続ける。
+  QString initialPath;
+  InstanceManager::Role role =
+      InstanceManager::instance()->bootstrap(a.arguments(), initialPath);
+  if (role == InstanceManager::Role::Forwarded) return 0;
+  if (role == InstanceManager::Role::Mothership) return a.exec();
+
   MyParams::instance()->initialize();
 
   QTranslator tra;
@@ -44,11 +61,19 @@ int main(int argc, char* argv[]) {
   QWindowsWindowFunctions::setWinTabEnabled(true);
 #endif
 
-  if (argc > 1) {
-    QString initialPath = QString::fromLocal8Bit(argv[1]);
+  if (!initialPath.isEmpty())
     MyParams::instance()->setCurrentXdtsPath(initialPath);
-  }
   MyWindow w;
+
+  // Worker windows receive reload/activate pushes from the mothership when
+  // another launch requests the file already open in this window.
+  // ワーカーウィンドウは、別の起動がこのウィンドウで既に開いているファイル
+  // を要求した際、母艦からの再読み込み・前面化の指示を受け取る。
+  if (role == InstanceManager::Role::Worker) {
+    QObject::connect(InstanceManager::instance(),
+                     &InstanceManager::reloadAndActivateRequested, &w,
+                     &MyWindow::reloadAndActivate);
+  }
 
   QRect geometry = MyParams::instance()->loadWindowGeometry();
   if (!geometry.isNull()) {

--- a/sources/mywindow.cpp
+++ b/sources/mywindow.cpp
@@ -6,6 +6,10 @@
 #include "tool.h"
 #include "commandmanager.h"
 #include "dialogs.h"
+#include "instancemanager.h"
+#ifdef WIN32
+#include <windows.h>
+#endif
 
 #include <iostream>
 #include <QPushButton>
@@ -860,6 +864,19 @@ void MyWindow::onLoad(const QString& xdtsPath) {
   }
   if (!currentXdtsPath.isEmpty())
     MyParams::instance()->setCurrentXdtsPath(currentXdtsPath);
+  // Keep the mothership process's open-file registry in sync with this
+  // window (File > Open / drag & drop may switch to a different file).
+  // 母艦プロセスの開いているファイル一覧をこのウィンドウと同期させる
+  // （File > Open
+  // やドラッグ＆ドロップで別ファイルに切り替わる場合があるため）。 Both paths
+  // of a paired genga/douga sheet are sent, since setCurrentXdtsPath() may have
+  // resolved a counterpart file into exposeAreas().
+  // 原画欄／動画欄のペアシートを開いている場合は、setCurrentXdtsPath()が
+  // 解決した相方のパスも含めて両方送る。
+  QStringList openXdtsPaths;
+  for (auto areaId : MyParams::instance()->exposeAreas())
+    openXdtsPaths << MyParams::instance()->currentXdtsPath(areaId);
+  InstanceManager::instance()->notifyPathChanged(openXdtsPaths);
 
   // 手描き画像のリセット
   m_previewPane->setScribbleImage(QImage());
@@ -1207,4 +1224,88 @@ void MyWindow::onBacksideImgPathChanged() {
 void MyWindow::onAbout() {
   static AboutDialog aboutDialog(this);
   aboutDialog.exec();
+}
+
+// Re-reads the XDTS timing data (m_data / m_columns / m_durations) only.
+// Unlike onLoad(), this deliberately skips askAndSaveChanges(), the
+// hand-drawn overlay reset, MyParams::resetValues(), and format settings
+// reload, so unsaved hand-drawn edits and undo history survive the reload.
+// XDTSのタイミングデータ（m_data / m_columns /
+// m_durations）のみ再読み込みする。
+// onLoad()と異なり、askAndSaveChanges()・手描きオーバーレイのリセット・
+// MyParams::resetValues()・フォーマット設定の再読み込みは意図的に行わない。
+// これにより、未保存の手描き編集とUndo履歴は再読み込み後も保持される。
+void MyWindow::reloadXdtsDataOnly() {
+  m_columns.clear();
+  m_durations.clear();
+
+  QList<ExportArea> areaIds = MyParams::instance()->exposeAreas();
+  for (auto areaId : areaIds) {
+    if (m_data) delete m_data;
+    m_data = new XdtsData();
+
+    QString path = MyParams::instance()->currentXdtsPath(areaId);
+
+    bool ok = loadXdtsScene(m_data, path);
+    if (!ok) {
+      QMessageBox::critical(this, tr("Error"),
+                            tr("%1 is not a valid XDTS file.").arg(path));
+      continue;
+    }
+
+    if (m_data->isEmpty() || m_data->timeTable().isEmpty()) continue;
+
+    XdtsTimeTableFieldItem cellField   = m_data->timeTable().getCellField();
+    XdtsTimeTableHeaderItem cellHeader = m_data->timeTable().getCellHeader();
+    int tmpDuration                    = m_data->timeTable().getDuration();
+    m_durations.insert(areaId, tmpDuration);
+    QStringList layerNames = cellHeader.getLayerNames();
+    QList<int> columns     = cellField.getOccupiedColumns();
+
+    ColumnsData data;
+    for (int column : columns) {
+      QString levelName = layerNames.at(column);
+      QList<int> tick1, tick2;
+      bool isHoldFrame = false;
+      QVector<FrameData> track =
+          cellField.getColumnTrack(column, tick1, tick2, isHoldFrame);
+      for (int i = track.size(); i < std::max(duration(), tmpDuration); i++) {
+        track.append({QString(), FrameOption_None});
+        isHoldFrame = false;
+      }
+      data.append({track, levelName, isHoldFrame});
+    }
+
+    m_columns.insert(areaId, data);
+  }
+
+  m_settingsDialog->setDuration(duration());
+  initTemplate();
+  updateTitleBar();
+}
+
+// Brings this window to the foreground after InstanceManager notifies it
+// that another launch requested the file already open here.
+// 別の起動がこのウィンドウで既に開いているファイルを要求したことを
+// InstanceManagerが通知してきた際に、このウィンドウを前面化する。
+void MyWindow::reloadAndActivate() {
+  reloadXdtsDataOnly();
+
+  if (isMinimized()) showNormal();
+#ifdef WIN32
+  // activateWindow() alone (SetForegroundWindow) is blocked by Windows'
+  // foreground-lock when this process isn't the active one; the taskbar
+  // button just flashes instead. Toggling the native HWND topmost flag is
+  // a Z-order change, not a foreground-steal request, so it isn't subject
+  // to that restriction.
+  // activateWindow()単体（内部でSetForegroundWindowを呼ぶ）は、このプロセスが
+  // アクティブでない場合Windowsのフォアグラウンドロックで拒否され、タスクバー
+  // アイコンが点滅するだけになる。ネイティブHWNDの最前面フラグの切り替えは
+  // フォアグラウンド奪取ではなくZ順序の変更なので、この制限を受けない。
+  HWND hwnd = reinterpret_cast<HWND>(winId());
+  SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+  SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+#endif
+  raise();
+  activateWindow();
 }

--- a/sources/mywindow.h
+++ b/sources/mywindow.h
@@ -43,6 +43,12 @@ class MyWindow : public QMainWindow {
 
   QAction* m_currentColorAction;
 
+  // Re-reads the XDTS timing data only, leaving hand-drawn overlays / undo
+  // history / format settings untouched. Used by reloadAndActivate().
+  // 手描きオーバーレイ・Undo履歴・フォーマット設定はそのままに、XDTSの
+  // タイミングデータのみ再読み込みする。reloadAndActivate() から呼ばれる。
+  void reloadXdtsDataOnly();
+
 public:
   MyWindow();
   ~MyWindow();
@@ -50,6 +56,14 @@ public:
   bool askAndSaveChanges();
   void setPage(int page);
   int duration();
+
+  // Requested by InstanceManager when another launch asks to open the file
+  // that is already open in this window: reloads the XDTS data (preserving
+  // unsaved hand-drawn edits) and brings the window to the foreground.
+  // 別プロセスの起動が、このウィンドウで既に開いているファイルを開こうとした
+  // 際にInstanceManagerから呼ばれる。XDTSデータを再読み込みし（未保存の手描き
+  // データは保持したまま）、ウィンドウを前面化する。
+  void reloadAndActivate();
 
 protected:
   void closeEvent(QCloseEvent* event) override;

--- a/sources/pathutils.cpp
+++ b/sources/pathutils.cpp
@@ -1,6 +1,7 @@
 #include "pathutils.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 #include <QCoreApplication>
 
@@ -35,4 +36,22 @@ QString getProjectRoot() {
 QString getLicenseFolderPath() { return getResourceDirPath() + "/LICENSE"; }
 
 QString getTranslationFolderPath() { return getResourceDirPath() + "/loc"; }
+
+// Falls back to a cleaned absolute path when the file doesn't exist yet, and
+// folds case on Windows (NTFS is case-insensitive).
+// ファイルがまだ存在しない場合は絶対パスをクリーンアップした値にフォールバックし、
+// Windows では大文字小文字を無視する（NTFSは大文字小文字を区別しないため）。
+QString canonicalizePath(const QString& path) {
+  if (path.isEmpty()) return QString();
+
+  QString canonical = QFileInfo(path).canonicalFilePath();
+  if (canonical.isEmpty())
+    canonical = QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+
+#ifndef __MACOS__
+  canonical = canonical.toLower();
+#endif
+
+  return canonical;
+}
 }  // namespace PathUtils

--- a/sources/pathutils.h
+++ b/sources/pathutils.h
@@ -13,5 +13,10 @@ QString getResourceDirPath();
 QString getProjectRoot();
 QString getLicenseFolderPath();
 QString getTranslationFolderPath();
+
+// Normalizes a path for cross-process "is this file already open"
+// comparisons (used by InstanceManager).
+// 別プロセス間で「同じファイルが既に開いているか」を比較するためにパスを正規化する。
+QString canonicalizePath(const QString& path);
 }  // namespace PathUtils
 #endif


### PR DESCRIPTION
This PR ensures that only one window is opened per XDTS file, even if XDTS Viewer is launched multiple times for the same file. 
This prevents conflicting edits from multiple windows on the same file. 
Additionally, if an XDTS file is modified externally and XDTS Viewer is relaunched with that file's path, the existing window's timing data is reloaded and refreshed, while any unsaved hand-drawn (scribble) edits are preserved.

On first launch, an invisible "mothership" process starts (detected via a QSharedMemory lock) and coordinates per-file "worker" windows, each running as its own child process, over IPC (QLocalServer/QLocalSocket). This coordination is implemented in the newly added `InstanceManager` class.
 When XDTS Viewer is launched with a path that's already open in an existing window — including either file of a paired genga/douga sheet — the mothership asks that window to reload its data and brings it to the foreground instead of opening a new one. 
The mothership process exits automatically once all windows have been closed.