### PR TITLE
Fix MacOS Doubled Dock Icon

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HEADERS
     xdtsio.h
     pathutils.h
     commandmanager.h
+    macdockicon.h
     ${MOC_HEADERS}
 )
 
@@ -54,6 +55,18 @@ elseif(CMAKE_HOST_APPLE)
     message(STATUS "Build environment is APPLE")
 else()
     message(ERROR "Unsupported build environment, only MSVC and APPLE are supported")
+endif()
+
+# macdockicon.mm is Objective-C++ (hides the mothership process's Dock icon
+# on macOS); only compiled for the Apple build, MSVC cannot build .mm files.
+# macdockicon.mmはObjective-C++（macOSで母艦プロセスのDockアイコンを隠す
+# ためのもの）。Appleビルドでのみコンパイルする。MSVCは.mmファイルを
+# ビルドできない。
+if(BUILD_ENV_APPLE)
+    set(SOURCES
+        ${SOURCES}
+        macdockicon.mm
+    )
 endif()
 
 #-----------------------------------------------------------------------------
@@ -166,6 +179,9 @@ if(BUILD_ENV_MSVC)
     target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Network ${PSD_SDK_LIB} )
 else()
     target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Network)
+    # AppKit is needed by macdockicon.mm (NSApplicationActivationPolicy).
+    # AppKitはmacdockicon.mm（NSApplicationActivationPolicy）に必要。
+    target_link_libraries(${PROJECT_NAME} "-framework AppKit")
 endif()
 
 add_definitions(

--- a/sources/instancemanager.cpp
+++ b/sources/instancemanager.cpp
@@ -2,6 +2,7 @@
 #include "pathutils.h"
 #include "xdtsio.h"
 #include "dialogs.h"
+#include "macdockicon.h"
 
 #include <QApplication>
 #include <QCoreApplication>
@@ -170,6 +171,17 @@ void InstanceManager::startMothership(const QString& initialPath) {
   // 代わりにonServerSocketDisconnected()（m_workersが空になったら終了）で
   // 明示的に制御する。
   qApp->setQuitOnLastWindowClosed(false);
+
+  // The mothership has no window, but on macOS every process that starts a
+  // Cocoa event loop still gets a Dock icon by default; hide it so the app
+  // doesn't show two Dock icons (one for this process, one for the worker
+  // window it spawns).
+  // 母艦はウィンドウを持たないが、macOSではCocoaのイベントループを開始した
+  // 各プロセスは既定でDockアイコンを持つ。起動するワーカーウィンドウの
+  // アイコンと並んで2つ表示されないよう、ここで隠す。
+#ifdef __MACOS__
+  hideDockIcon();
+#endif
 
   // Treat our own launch argument the same way as a request coming from
   // another process (always spawns a worker, since nothing is registered

--- a/sources/macdockicon.h
+++ b/sources/macdockicon.h
@@ -1,0 +1,25 @@
+﻿#pragma once
+#ifndef MACDOCKICON_H
+#define MACDOCKICON_H
+
+#ifdef __MACOS__
+// Hides this process's Dock icon and Cmd+Tab entry
+// (NSApplicationActivationPolicyAccessory). The invisible mothership
+// process has no window of its own, but every process that starts a Cocoa
+// event loop gets a Dock icon by default -- without this, launching XDTS
+// Viewer shows two Dock icons (one for the mothership, one for the
+// per-file worker window) instead of one. Safe to call at any time after
+// QApplication is constructed; it does not prevent this process from
+// later showing dialogs (e.g. the CSP sync picker) in the foreground.
+// このプロセスのDockアイコンとCmd+Tabへの表示を隠す
+// （NSApplicationActivationPolicyAccessory）。母艦プロセスは自身の
+// ウィンドウを持たないが、Cocoaのイベントループを開始した各プロセスは
+// 既定でDockアイコンを1つ持つため、これを行わないとXDTS Viewer起動時に
+// Dockアイコンが2つ（母艦用とファイルごとのワーカーウィンドウ用）表示
+// されてしまう。QApplication構築後であればいつ呼んでも良く、これを
+// 呼んだ後もこのプロセスがCSP同期ピッカーなどのダイアログを前面に表示
+// することは妨げられない。
+void hideDockIcon();
+#endif
+
+#endif

--- a/sources/macdockicon.mm
+++ b/sources/macdockicon.mm
@@ -1,0 +1,9 @@
+#include "macdockicon.h"
+
+#ifdef __MACOS__
+#import <AppKit/AppKit.h>
+
+void hideDockIcon() {
+  [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+#endif


### PR DESCRIPTION
This PR resolves an issue in the macOS version where two Dock icons were displayed at startup.
A process to enable the `NSApplicationActivationPolicyAccessory` policy has been added when the “mother ship” process starts.